### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,15 @@
   },
   "homepage": "https://github.com/christophwitzko/tripple-semicolon",
   "dependencies": {
-    "esformatter": "^0.4.3",
-    "esformatter-semicolons": "^1.0.3",
-    "minimist": "^1.1.0"
+    "esformatter": "0.4.3",
+    "esformatter-semicolons": "1.1.2",
+    "minimist": "1.2.0"
   },
   "devDependencies": {
-    "semantic-release": "^3.0.2",
-    "standard": "^2.3.1",
-    "tap-spec": "^2.2.1",
-    "tape": "^3.5.0"
+    "semantic-release": "3.4.1",
+    "standard": "2.11.0",
+    "tap-spec": "2.2.2",
+    "tape": "3.5.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:
- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/) – they’re always in a state you know about.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:
