### PR TITLE
Updated tape to version 4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "semantic-release": "3.4.1",
     "standard": "2.11.0",
     "tap-spec": "2.2.2",
-    "tape": "3.5.0"
+    "tape": "4.2.1"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
:rocket:

tape just published version 4.2.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 46 commits (ahead by 46, behind by 0).
- [0dc9313](https://github.com/substack/tape/commit/0dc93136f0e6e1ae83a9cb5e1117b72028fd9d47): v4.2.1
- [77e1848](https://github.com/substack/tape/commit/77e184843f955722e261f81e50c5cc10f06784fd): Use `string.prototype.trim` instead of relying on `String#trim`, for ES3.
- [1e22819](https://github.com/substack/tape/commit/1e22819419ca4230e9a86e0405f51cee17c99972): Merge pull request #195 from wbinnssmith/patch-1
- [df62458](https://github.com/substack/tape/commit/df624584d8420848bfcb340a62701dcd717867af): Add Node v4
- [0e407f0](https://github.com/substack/tape/commit/0e407f05d66c6e29ef26989d659db99b86b40a64): Bumping `defined` to v1.0.0 - no implementation change, just follows semver now.
- [4711573](https://github.com/substack/tape/commit/47115739d4fb7360891c807335cc1ffbf2a2a0d6): Merge pull request #189 from gritzko/master
- [c22ad78](https://github.com/substack/tape/commit/c22ad7857655b779fdab6002a0b4902e4e130d9b): add tape-dom link to the readme
- [aadcf4a](https://github.com/substack/tape/commit/aadcf4a95ed6810fa404dbe01f3b745252d4f12e): 4.2.0
- [88d567c](https://github.com/substack/tape/commit/88d567cdd9fcc0f7016029b8aa97e8439edb85c4): Use `function-bind` to ensure we're robust against modification of `Function#call`
- [e82c1e8](https://github.com/substack/tape/commit/e82c1e8e7a5d5ad420fc9efc8accfaa11b7dd12c): Use `has` instead of a homegrown version of the same.
- [e416a8e](https://github.com/substack/tape/commit/e416a8e2ca479c973e43f4186dddb8817fcc88d9): 4.1.0
- [e08f4de](https://github.com/substack/tape/commit/e08f4de24a274000c3d126f04b32e70f2ed619a4): Merge pull request #171 from hayes/fix-stack-yaml
- [b73d2bf](https://github.com/substack/tape/commit/b73d2bfb69364f5332f5958bca2c69099aedc290): improve yaml formatting of diagnostic information
- [d26e522](https://github.com/substack/tape/commit/d26e5224cb39988fbafb8cb99dbc59b714ccab9b): Merge pull request #170 from TehShrike/master
- [fc889f5](https://github.com/substack/tape/commit/fc889f56b418fbb30150d517ed7d8b8aa5b943d4): Exposing the whole test harness

There are 46 commits in total. See the [full diff](https://github.com/substack/tape/compare/51f2f97d7eade23b1e23b7cfea37f449ade5b9c3...0dc93136f0e6e1ae83a9cb5e1117b72028fd9d47).
